### PR TITLE
Fix Fintoc object mixup error

### DIFF
--- a/src/lib/core.ts
+++ b/src/lib/core.ts
@@ -39,15 +39,18 @@ export const getFintoc = (): Promise<Fintoc | null> => new Promise((resolve) => 
     return;
   }
 
+  if (window.Fintoc) {
+    resolve(window.Fintoc);
+    return;
+  }
+
   let script = findScript();
 
   if (!script) {
     script = injectScript();
-
-    script.onload = () => {
-      resolve(window.Fintoc);
-    };
-  } else {
-    resolve(window.Fintoc);
   }
+
+  script.onload = () => {
+    resolve(window.Fintoc);
+  };
 });


### PR DESCRIPTION
## Description

The Fintoc object was incorrectly being returned as `undefined` when it was being loaded multiple times in a short period of time. This PR should fix that.

## Requirements

None.

## Additional changes

None.
